### PR TITLE
Queue API changes

### DIFF
--- a/Squeenix.lua
+++ b/Squeenix.lua
@@ -26,16 +26,13 @@ function Squeenix:ADDON_LOADED(event, addon)
 	MiniMapTracking:ClearAllPoints()
 	MiniMapTracking:SetPoint("BOTTOMRIGHT", Minimap, "TOPLEFT", 5, -18)
 
-	MiniMapBattlefieldFrame:ClearAllPoints()
-	MiniMapBattlefieldFrame:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", 13, 0)
+	QueueStatusMinimapButton:ClearAllPoints()
+	QueueStatusMinimapButton:SetPoint("TOPRIGHT", Minimap, "BOTTOMLEFT", 5, 18)
 
 	MiniMapWorldMapButton:ClearAllPoints()
 	MiniMapWorldMapButton:SetPoint("BOTTOMLEFT", Minimap, "BOTTOMLEFT", -11, -8)
 	MiniMapWorldMapButton:SetNormalTexture("Interface\\Addons\\Squeenix\\WorldMapSquare.tga")
 	MiniMapWorldMapButton:SetPushedTexture("Interface\\Addons\\Squeenix\\WorldMapSquare.tga")
-
-	MiniMapLFGFrame:ClearAllPoints()
-	MiniMapLFGFrame:SetPoint("TOPRIGHT", Minimap, "TOPLEFT", 5, -53)
 
 	MiniMapVoiceChatFrame:ClearAllPoints()
 	MiniMapVoiceChatFrame:SetPoint("BOTTOMRIGHT", Minimap, "BOTTOMLEFT", 5, 20)


### PR DESCRIPTION
Blizzard has merged the PVE and PVP queues, so the `MiniMapBattleFrame` and `MiniMapLFGFrame` are replaced with `QueueStatusMinimapButton`. 
